### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM pytorch/pytorch:1.9.0-cuda10.2-cudnn7-runtime
+FROM pytorch/pytorch:2.3.0-cuda12.1-cudnn8-runtime
 
 RUN apt-get update && \
     apt-get upgrade -y && \


### PR DESCRIPTION
Old base image has Python 3.7, which is deprecated. Update to most recent version of base image with Python 3.10.